### PR TITLE
fix: ai4-metadata.yml path definition

### DIFF
--- a/{{ cookiecutter.__repo_name }}/api/config.py
+++ b/{{ cookiecutter.__repo_name }}/api/config.py
@@ -9,6 +9,7 @@ By convention, the CONSTANTS defined in this module are in UPPER_CASE.
 """
 import logging
 import os
+from pathlib import Path
 from importlib import metadata
 import yaml
 
@@ -23,18 +24,12 @@ PACKAGE_METADATA = metadata.metadata(API_NAME)  # .json
 
 # Get ai4-metadata.yaml metadata
 CWD = os.getcwd()
-REPO_NAME = "{{ cookiecutter.__repo_name }}"
-AI4_METADATA_DIR = os.getenv(f"{API_NAME.capitalize()}_AI4_METADATA_DIR")
-if AI4_METADATA_DIR is None:
-    if "ai4-metadata.yml" in os.listdir(f"{CWD}/{REPO_NAME}"):
-        AI4_METADATA_DIR = f"{CWD}/{REPO_NAME}"
-    elif "ai4-metadata.yml" in os.listdir(f"{CWD}/../{REPO_NAME}"):
-        AI4_METADATA_DIR = f"{CWD}/../{REPO_NAME}"
-
-# Open ai4-metadata.yml
-_file = f"{AI4_METADATA_DIR}/ai4-metadata.yml"
-with open(_file, "r", encoding="utf-8") as stream:
-    AI4_METADATA = yaml.safe_load(stream)
+try:
+    AI4_METADATA_PATH = sorted(Path(CWD).rglob("ai4-metadata.yml"))[0]
+    with open(AI4_METADATA_PATH, "r", encoding="utf-8") as stream:
+        AI4_METADATA = yaml.safe_load(stream)
+except IndexError:
+    AI4_METADATA = {"description": "-"}
 
 # Project metadata
 PROJECT_METADATA = {

--- a/{{ cookiecutter.__repo_name }}/api/config.py
+++ b/{{ cookiecutter.__repo_name }}/api/config.py
@@ -23,12 +23,13 @@ PACKAGE_METADATA = metadata.metadata(API_NAME)  # .json
 
 # Get ai4-metadata.yaml metadata
 CWD = os.getcwd()
+REPO_NAME = "{{ cookiecutter.__repo_name }}"
 AI4_METADATA_DIR = os.getenv(f"{API_NAME.capitalize()}_AI4_METADATA_DIR")
 if AI4_METADATA_DIR is None:
-    if "ai4-metadata.yml" in os.listdir(f"{CWD}/{API_NAME}"):
-        AI4_METADATA_DIR = f"{CWD}/{API_NAME}"
-    elif "ai4-metadata.yml" in os.listdir(f"{CWD}/../{API_NAME}"):
-        AI4_METADATA_DIR = f"{CWD}/../{API_NAME}"
+    if "ai4-metadata.yml" in os.listdir(f"{CWD}/{REPO_NAME}"):
+        AI4_METADATA_DIR = f"{CWD}/{REPO_NAME}"
+    elif "ai4-metadata.yml" in os.listdir(f"{CWD}/../{REPO_NAME}"):
+        AI4_METADATA_DIR = f"{CWD}/../{REPO_NAME}"
 
 # Open ai4-metadata.yml
 _file = f"{AI4_METADATA_DIR}/ai4-metadata.yml"


### PR DESCRIPTION
Hiya,

while implementing a repo generated by this template on the platform, the following error occurred:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/srv/my-module/api/__init__.py", line 13, in <module>
    from . import config, responses, schemas, utils
  File "/srv/my-module/api/config.py", line 33, in <module>
    if "ai4-metadata.yml" in os.listdir(f"{CWD}/{API_NAME}"):
FileNotFoundError: [Errno 2] No such file or directory: '/srv/my_module'
```
I found this was due to some lines in the [api/config.py file](https://github.com/ai4os/ai4-template-adv/blob/6d04de0b5d0f5b7b7473ef6a7270e209baa49e3c/%7B%7B%20cookiecutter.__repo_name%20%7D%7D/api/config.py#L28) which seem to look for the `ai4-metadata.yml` file in the api directory, even though it's actually located in the repo directory.

The fix I've added here worked in my deployment, so I thought I'd propose it "officially".